### PR TITLE
[docs] No need to install arch packages in base

### DIFF
--- a/doc/installation.md
+++ b/doc/installation.md
@@ -81,7 +81,7 @@ sudo apt install -y git gcc make libcap2-bin libtool
 sudo yum install -y git gcc make libcap libtool
 
 # Archlinux-based distributions:
-sudo pacman --noconfirm -S git gcc make libcap libtool
+sudo pacman --noconfirm -S git gcc make libtool
 
 git clone --recurse-submodules https://github.com/NVIDIA/enroot.git
 ```
@@ -98,8 +98,8 @@ sudo yum install -y bash coreutils curl gawk jq parallel shadow-utils squashfs-t
 sudo yum install -y pv pigz ncurses libnvidia-container-tools squashfuse fuse-overlayfs # optional
 
 # Archlinux-based distributions
-sudo pacman --noconfirm -S bash coreutils curl gawk jq parallel shadow squashfs-tools grep findutils gzip glibc sed tar util-linux
-sudo pacman --noconfirm -S pv pigz ncurses libnvidia-container-tools squashfuse fuse-overlayfs # optional
+sudo pacman --noconfirm -S jq parallel squashfs-tools
+sudo pacman --noconfirm -S fuse-overlayfs libnvidia-container-tools pigz pv squashfuse # optional
 ```
 
 Build and install Enroot:

--- a/doc/installation.md
+++ b/doc/installation.md
@@ -94,8 +94,8 @@ sudo apt install -y fuse-overlayfs libnvidia-container-tools pigz pv squashfuse 
 
 # RHEL-based distributions
 sudo yum install -y epel-release # required on some distributions
-sudo yum install -y bash coreutils curl gawk jq parallel shadow-utils squashfs-tools grep findutils gzip glibc-common sed tar util-linux
-sudo yum install -y pv pigz ncurses libnvidia-container-tools squashfuse fuse-overlayfs # optional
+sudo yum install -y jq squashfs-tools parallel
+sudo yum install -y fuse-overlayfs libnvidia-container-tools pigz pv squashfuse # optional
 
 # Archlinux-based distributions
 sudo pacman --noconfirm -S jq parallel squashfs-tools

--- a/doc/installation.md
+++ b/doc/installation.md
@@ -89,8 +89,8 @@ git clone --recurse-submodules https://github.com/NVIDIA/enroot.git
 Install the runtime dependencies:
 ```sh
 # Debian-based distributions
-sudo apt install -y bash coreutils curl gawk jq parallel passwd squashfs-tools grep findutils gzip libc-bin sed tar util-linux
-sudo apt install -y pv pigz ncurses-bin libnvidia-container-tools squashfuse fuse-overlayfs # optional
+sudo apt install -y curl gawk jq squashfs-tools parallel
+sudo apt install -y fuse-overlayfs libnvidia-container-tools pigz pv squashfuse # optional
 
 # RHEL-based distributions
 sudo yum install -y epel-release # required on some distributions


### PR DESCRIPTION
Tested with:
```Dockerfile
FROM archlinux/base
RUN pacman -Sy --noconfirm base
RUN pacman -Q \
        git gcc make libtool \
        bash coreutils curl gawk jq parallel shadow squashfs-tools grep findutils gzip glibc sed tar util-linux \
        pv pigz ncurses libnvidia-container-tools squashfuse fuse-overlayfs
```