### PR TITLE
Update PMIx detection

### DIFF
--- a/conf/hooks/50-slurm-pmi.sh
+++ b/conf/hooks/50-slurm-pmi.sh
@@ -14,7 +14,7 @@ for var in $(compgen -e "SLURM_"); do
 done
 
 # Check for PMIx support.
-if compgen -e "PMIX_" > /dev/null; then
+if [[ -z "${SLURM_MPI_TYPE-}" || "${SLURM_MPI_TYPE}" == pmix* ]] && compgen -e "PMIX_" > /dev/null; then
     # shellcheck disable=SC1090
     source "${ENROOT_LIBRARY_PATH}/common.sh"
 


### PR DESCRIPTION
If SLURM_MPI_TYPE is set, it must be "pmix*" to enable the PMIx part of
the hook. This is more precise than simply checking for the existence of
PMIX_* envvars.

The goal is to avoid creating mounts for the PMIx runtime dirs which
will fail because they don't actually exist on the host. This can happen
when the user specifies `--mpi=none` and also sets e.g. PMIX_foo=bar. It
may seem like this should never happen, but this actually does happen in
the context of pyxis for one of our HPC clusters.