### PR TITLE
enroot.in: fix typo

### DIFF
--- a/enroot.in
+++ b/enroot.in
@@ -158,7 +158,7 @@ enroot::usage() {
 		
 		 Schemes:
 		   docker://[USER@][REGISTRY#]IMAGE[:TAG]  Import a Docker image from a registry
-		   dockerd://IMAGE[:TAG]                   Import a Docker image from the Docker daemon
+		   docker://IMAGE[:TAG]                    Import a Docker image from the Docker daemon
 		
 		 Options:
 		   -a, --arch    Architecture of the image (defaults to host architecture)


### PR DESCRIPTION
I believe `dockerd` in `dockerd://IMAGE[:TAG]` should be `docker`.