### PR TITLE
Fix remove for dirs without search perms

### DIFF
--- a/src/common.sh
+++ b/src/common.sh
@@ -69,7 +69,7 @@ common::rmall() {
     local -r path="$1"
 
     rm --one-file-system --preserve-root -rf "${path}" 2> /dev/null || \
-    { chmod -f -R +w "${path}"; rm --one-file-system --preserve-root -rf "${path}"; }
+    { chmod -f -R +wX "${path}"; rm --one-file-system --preserve-root -rf "${path}"; }
 }
 
 common::mktmpdir() {


### PR DESCRIPTION
Repro:
```shell
$ enroot import docker://ubuntu
$ enroot create ubuntu.sqsh
$ enroot start -r -w ubuntu chmod -R 0644 /usr
$ enroot remove -f ubuntu
$ enroot create ubuntu.sqsh
[ERROR] File already exists: /home/lyeager/.local/share/enroot/ubuntu
```