### PR TITLE
Allow for config drop-ins

### DIFF
--- a/enroot.in
+++ b/enroot.in
@@ -28,7 +28,7 @@ config::export() {
     [ -n "${3-}" ] && export "$1=$2" || export "$1=${!1:-$2}"
 }
 
-config::init() {
+config::load() {
     local -r file="$1" overwrite="${2-}"
 
     if [ -s "${file}" ] && ! "${BASH}" -n "${file}" > /dev/null 2>&1; then
@@ -45,6 +45,19 @@ config::init() {
             fi
         done < "${file}"
    fi
+}
+
+config::init() {
+    local -r file="$1" overwrite="${2-}"
+
+    config::load "${file}" "${overwrite}"
+    if [ -d "${file}.d" ]; then
+      shopt -s nullglob
+      for dropin in "${file}.d"/*".conf"; do
+        config::load "${dropin}" "${overwrite}"
+      done
+      shopt -u nullglob
+    fi
 }
 
 config::fini() {


### PR DESCRIPTION
Enhancement to /etc/enroot/enroot.conf:
If the directory /etc/enroot/enroot.conf.d exisits,
also load all files named *.conf in the same manner as the .conf file
in asciicographical order (modulo LC_COLLATE)