### PR TITLE
[rpm] Fix script ordering

### DIFF
--- a/pkg/rpm/SPECS/enroot.spec
+++ b/pkg/rpm/SPECS/enroot.spec
@@ -43,7 +43,7 @@ unprivileged sandboxes.
 
 This dependency package grants extra capabilities to unprivileged users which
 allows them to import and convert container images directly.
-%post -n %{name}+caps
+%posttrans -n %{name}+caps
 /usr/sbin/setcap cap_sys_admin+ep %{_bindir}/enroot-mksquashovlfs
 /usr/sbin/setcap cap_sys_admin,cap_mknod+pe %{_bindir}/enroot-aufs2ovlfs
 %preun -n %{name}+caps


### PR DESCRIPTION
since `%perun` of old runs _after_ `%post` of new, upgrades break.
Use `%posttrans` insead, which runs last

Fixes #79 again