### PR TITLE
add crane support

### DIFF
--- a/doc/cmd/import.md
+++ b/doc/cmd/import.md
@@ -9,6 +9,7 @@ Import a container image from a specific location.
    docker://[USER@][REGISTRY#]IMAGE[:TAG]  Import a Docker image from a registry
    dockerd://IMAGE[:TAG]                   Import a Docker image from the Docker daemon
    podman://IMAGE[:TAG]                    Import a Docker image from a local Podman repository
+   crane://IMAGE[:TAG]                     Import a Docker image from a registry
 
  Options:
    -a, --arch    Architecture of the image (defaults to host architecture)
@@ -55,6 +56,13 @@ Requires the Docker CLI to communicate with the Docker daemon.
 Docker image manifest version 2, schema 2.  
 Requires the Podman CLI to communicate with the local Podman repository.
 
+#### [Crane (crane://)](https://github.com/google/go-containerregistry/blob/main/cmd/crane/README.md)
+
+Docker image manifest version 2, schema 2.
+This schema permits to import container images from  docker registries
+without Docker or Podman, only using the crane executable that does not require any special permission for use.
+You should use the repository prefix when importing images, for instance: `docker.io` or `quay.io`.
+
 # Configuration
 
 | Setting | Default | Description |
@@ -74,6 +82,9 @@ Requires the Podman CLI to communicate with the local Podman repository.
 ```sh
 # Import Tensorflow 19.01 from NVIDIA GPU Cloud
 $ enroot import --output tensorflow.sqsh 'docker://$oauthtoken@nvcr.io#nvidia/tensorflow:19.01-py3'
+
+# Import ubuntu:20.04 from docker hub using crane
+$ enroot import --output ubuntu.sqsh crane://docker.io/ubuntu:20.04
 ```
 
 # Known issues

--- a/src/docker.sh
+++ b/src/docker.sh
@@ -345,6 +345,8 @@ docker::daemon::import() (
         engine="docker" ;;
     podman://*)
         engine="podman" ;;
+    crane://*)
+        engine="crane" ;;
     esac
 
     common::checkcmd jq "${engine}" mksquashfs tar
@@ -377,18 +379,25 @@ docker::daemon::import() (
     tmpdir=$(common::mktmpdir enroot)
     common::chdir "${tmpdir}"
 
-    # Download the image (if necessary) and create a container for extraction.
-    common::log INFO "Fetching image" NL
-    # TODO Use --platform once it comes out of experimental.
-    "${engine}" create --name "${PWD##*/}" "${image}" >&2
-    common::log
-
-    # Extract and configure the rootfs.
-    common::log INFO "Extracting image content..."
+    common::log INFO "Creating and fixing permissions of rootfs"
     mkdir rootfs
-    "${engine}" export "${PWD##*/}" | tar -C rootfs --warning=no-timestamp --anchored --exclude='dev/*' --exclude='.dockerenv' -px
     common::fixperms rootfs
-    "${engine}" inspect "${image}" | common::jq '.[] | with_entries(.key|=ascii_downcase)' > config
+
+    if [[ "${engine}" != "crane" ]]; then
+        # Download the image (if necessary) and create a container for extraction.
+        common::log INFO "Fetching image" NL
+        # TODO Use --platform once it comes out of experimental.
+        "${engine}" create --name "${PWD##*/}" "${image}" >&2
+
+        # Extract and configure the rootfs.
+        common::log INFO "Extracting image content..." NL
+        "${engine}" export "${PWD##*/}" | tar -C rootfs --warning=no-timestamp --anchored --exclude='dev/*' --exclude='.dockerenv' -px
+        "${engine}" inspect "${image}" | common::jq '.[] | with_entries(.key|=ascii_downcase)' > config
+    else
+        common::log INFO "Fetching image and extracting its contents..." NL
+        ${engine} export "${image}" /dev/stdout |tar -C rootfs --warning=no-timestamp --anchored --exclude='dev/*' --exclude='.dockerenv' -px
+        ${engine} config "${image}"| common::jq 'with_entries(.key|=ascii_downcase)' > config
+    fi
     docker::configure rootfs config "${arch}"
 
     # Create the final squashfs filesystem.

--- a/src/runtime.sh
+++ b/src/runtime.sh
@@ -435,7 +435,7 @@ runtime::import() {
     case "${uri}" in
     docker://*)
         docker::import "${uri}" "${filename}" "${arch}" ;;
-    dockerd://* | podman://*)
+    dockerd://* | podman://* | crane://*)
         docker::daemon::import "${uri}" "${filename}" "${arch}" ;;
     *)
         common::err "Invalid argument: ${uri}" ;;


### PR DESCRIPTION
Add option to import docker images using [google crane](https://github.com/google/go-containerregistry/blob/main/cmd/crane/doc/crane.md). This schema is useful to import images without setting up docker or podman. Useful for CI/CD settings where could be complicated or not recommended to run dind (docker in docker) or podman in podman. The google crane only uses the authentication information of the repository with no needs for special configuration or permissions.