### PR TITLE
makefile: actually make DESTDIR an absolute path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,11 +6,12 @@ sysconfdir  ?= $(prefix)/etc
 datarootdir ?= $(prefix)/share
 datadir     ?= $(datarootdir)
 
-DESTDIR     := $(abspath $(DESTDIR))
-BINDIR      = $(DESTDIR)$(bindir)
-LIBDIR      = $(DESTDIR)$(libdir)/enroot
-SYSCONFDIR  = $(DESTDIR)$(sysconfdir)/enroot
-DATADIR     = $(DESTDIR)$(datadir)/enroot
+override DESTDIR := $(abspath $(DESTDIR))
+
+BINDIR     = $(DESTDIR)$(bindir)
+LIBDIR     = $(DESTDIR)$(libdir)/enroot
+SYSCONFDIR = $(DESTDIR)$(sysconfdir)/enroot
+DATADIR    = $(DESTDIR)$(datadir)/enroot
 
 VERSION       := 3.3.0
 PACKAGE       ?= enroot


### PR DESCRIPTION
Currently, this works `DESTDIR=./install make install`, but this doesn't `make DESTDIR=./install install`.

We could also just remove the whole line, but I assume you had it in there for some good reason.