### PR TITLE
fix authentication for ECR

### DIFF
--- a/src/docker.sh
+++ b/src/docker.sh
@@ -73,7 +73,7 @@ docker::_authenticate() {
         ;;
     Basic)
         # Check that we have valid credentials and save them if successful.
-        CURL_ERROUT=1 common::curl "${curl_opts[@]}" -G -v ${req_params[@]+"${req_params[@]}"} -- "${url}" \
+        CURL_ERROUT=1 common::curl "${curl_opts[@]}" -w -G -v ${req_params[@]+"${req_params[@]}"} -- "${url}" \
           | awk '/Authorization: Basic/ { sub(/\r/, "", $4); print $4 }' \
           | common::read -r token
         ;;


### PR DESCRIPTION
Fixes #143 

It's a bit gross, but auth token needs to be retrieved using IAM credentials. Once retrieved, can be used with v2 OCI API.

This is the solution from the temp patch referred to in #59 but the final fix merged in looks like it tried to adopt using the get-login-password response.

Let me know what you think, sorry it took a while to come help out.