### PR TITLE
Apply ENROOT_MAX_PROCESSORS to unsquashfs

### DIFF
--- a/doc/cmd/create.md
+++ b/doc/cmd/create.md
@@ -19,6 +19,7 @@ The resulting root filesystem can be started with the [start](start.md) command 
 
 | Setting | Default | Description |
 | ------ | ------ | ------ |
+| `ENROOT_MAX_PROCESSORS` | `$(nproc)` | Maximum number of processors to use for parallel tasks (0 means unlimited) |
 | `ENROOT_FORCE_OVERRIDE` | `no` | Overwrite the root filesystem if it already exists (same as `--force`) |
 
 # Example

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -16,6 +16,7 @@ The following table describes standard paths used by the runtime:
 | `ENROOT_CACHE_PATH` | `${XDG_CACHE_HOME}/enroot` | Path to user image/credentials cache |
 | `ENROOT_DATA_PATH` | `${XDG_DATA_HOME}/enroot` | Path to user container storage |
 | `ENROOT_TEMP_PATH` | `${TMPDIR}` | Path to temporary directory |
+| `ENROOT_NUM_THREADS` | empty | Number of threads for image extraction |
 
 When `enroot.conf` has been read, and if there is a directory `enroot.conf.d` next to `enroot.conf`, all files in that directory matching `*.conf` will be considered, too.
 

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -16,7 +16,6 @@ The following table describes standard paths used by the runtime:
 | `ENROOT_CACHE_PATH` | `${XDG_CACHE_HOME}/enroot` | Path to user image/credentials cache |
 | `ENROOT_DATA_PATH` | `${XDG_DATA_HOME}/enroot` | Path to user container storage |
 | `ENROOT_TEMP_PATH` | `${TMPDIR}` | Path to temporary directory |
-| `ENROOT_NUM_THREADS` | empty | Number of threads for image extraction |
 
 When `enroot.conf` has been read, and if there is a directory `enroot.conf.d` next to `enroot.conf`, all files in that directory matching `*.conf` will be considered, too.
 

--- a/src/runtime.sh
+++ b/src/runtime.sh
@@ -418,7 +418,7 @@ runtime::create() {
     common::log INFO "Extracting squashfs filesystem..." NL
     # XXX: https://github.com/NVIDIA/enroot/issues/90
     [ $(ulimit -n) -gt $((2**26)) ] && ulimit -n $((2**26))
-    unsquashfs ${TTY_OFF+-no-progress} -user-xattrs -d "${rootfs}" "${image}" >&2
+    unsquashfs ${TTY_OFF+-no-progress} ${ENROOT_NUM_THREADS+-p $ENROOT_NUM_THREADS} -user-xattrs -d "${rootfs}" "${image}" >&2
     common::fixperms "${rootfs}"
 }
 
@@ -622,7 +622,7 @@ runtime::bundle() (
 
     # Extract the container rootfs from the image.
     common::log INFO "Extracting squashfs filesystem..." NL
-    unsquashfs ${TTY_OFF+-no-progress} -user-xattrs -f -d "${tmpdir}" "${image}" >&2
+    unsquashfs ${TTY_OFF+-no-progress} ${ENROOT_NUM_THREADS+-p $ENROOT_NUM_THREADS} -user-xattrs -f -d "${tmpdir}" "${image}" >&2
     common::fixperms "${tmpdir}"
     common::log
 

--- a/src/runtime.sh
+++ b/src/runtime.sh
@@ -418,7 +418,7 @@ runtime::create() {
     common::log INFO "Extracting squashfs filesystem..." NL
     # XXX: https://github.com/NVIDIA/enroot/issues/90
     [ $(ulimit -n) -gt $((2**26)) ] && ulimit -n $((2**26))
-    unsquashfs ${TTY_OFF+-no-progress} ${ENROOT_NUM_THREADS+-p $ENROOT_NUM_THREADS} -user-xattrs -d "${rootfs}" "${image}" >&2
+    unsquashfs ${TTY_OFF+-no-progress} -processors "${ENROOT_MAX_PROCESSORS}" -user-xattrs -d "${rootfs}" "${image}" >&2
     common::fixperms "${rootfs}"
 }
 
@@ -622,7 +622,7 @@ runtime::bundle() (
 
     # Extract the container rootfs from the image.
     common::log INFO "Extracting squashfs filesystem..." NL
-    unsquashfs ${TTY_OFF+-no-progress} ${ENROOT_NUM_THREADS+-p $ENROOT_NUM_THREADS} -user-xattrs -f -d "${tmpdir}" "${image}" >&2
+    unsquashfs ${TTY_OFF+-no-progress} -processors "${ENROOT_MAX_PROCESSORS}" -user-xattrs -f -d "${tmpdir}" "${image}" >&2
     common::fixperms "${tmpdir}"
     common::log
 


### PR DESCRIPTION
Currently, enroot calls `unsquashfs` such that it will use all installed processors, which may not always be desirable. E.g., running a non-exclusive Slurm job restricts the number of usable processors, in our case 2 by default. I timed `unsquashfs` under these conditions, with and without explicitly setting the number of processors to use:
```
$ time unsquashfs -p 2 -user-xattrs -d /run/enroot-data/user-$UID/container /netscratch/enroot/nvcr.io_nvidia_pytorch_23.12-py3.sqsh
Parallel unsquashfs: Using 2 processors
...
real    0m37.332s
user    0m40.923s
sys     0m28.742s
$ rm -rf /run/enroot-data/user-$UID/container
$ time unsquashfs -user-xattrs -d /run/enroot-data/user-$UID/container /netscratch/enroot/nvcr.io_nvidia_pytorch_23.12-py3.sqsh
Parallel unsquashfs: Using 40 processors
...
real    0m41.553s
user    0m38.024s
sys     0m28.396s
```
On this older machine, setting an appropriate number of processors reduces the runtime by about 10%.

This pull request ~adds a new config variable, `ENROOT_NUM_THREADS`, which allows controlling the number of processors used by~ applies `ENROOT_MAX_PROCESSORS` to `unsquashfs`. ~It is unset by default, which maintains the current behavior.~