### PR TITLE
feat: do not override OMP_NUM_THREADS if user set cpus-per-task

### DIFF
--- a/conf/hooks/extra/50-slurm-pytorch.sh
+++ b/conf/hooks/extra/50-slurm-pytorch.sh
@@ -36,7 +36,10 @@ if [ -n "${SLURM_LOCALID-}" ] && ! grep -q "^LOCAL_RANK=" "${ENROOT_ENVIRON}"; t
     printf "LOCAL_RANK=%s\n" "${SLURM_LOCALID}" >> "${ENROOT_ENVIRON}"
 fi
 
-# Matching the behavior of torch.distributed.run: https://github.com/pytorch/pytorch/blob/v1.9.0/torch/distributed/run.py#L521-L532
+# Follow "Multiprocessing best practices" from https://github.com/pytorch/pytorch/blob/v2.1.0/docs/source/notes/multiprocessing.rst
+# If user explicity set cpus-per-task use that value, otherwise compute based on number of CPUS and tasks on node.
 if [ "${SLURM_STEP_NUM_TASKS:-1}" -gt "${SLURM_STEP_NUM_NODES:-1}" ] && ! grep -q "^OMP_NUM_THREADS=" "${ENROOT_ENVIRON}"; then
-    printf "OMP_NUM_THREADS=1\n" >> "${ENROOT_ENVIRON}"
+    _slurm_cpus_per_task=${SLURM_CPUS_PER_TASK:-$((${SLURM_CPUS_ON_NODE}/(${SLURM_STEP_NUM_TASKS}/${SLURM_STEP_NUM_NODES})))}
+
+    printf "OMP_NUM_THREADS=${_slurm_cpus_per_task}\n" >> "${ENROOT_ENVIRON}"
 fi


### PR DESCRIPTION
Update OMP_NUM_THREADS based on "Multiprocessing best practices" from https://github.com/pytorch/pytorch/blob/v2.1.0/docs/source/notes/multiprocessing.rst. If user set cpus-per-task, use that value, otherwise compute based on number of CPUs and number of tasks on node.