### PR TITLE
Copy /etc/localtime symlink and target instead of mounting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,13 +43,14 @@ CONFIGFILE := enroot.conf
 CONFIG := conf/$(CONFIGFILE)
 CONFIGINFO := conf/$(CONFIGFILE).d/README
 
-HOOKS := conf/hooks/10-aptfix.sh   \
-         conf/hooks/10-cgroups.sh  \
-         conf/hooks/10-devices.sh  \
-         conf/hooks/10-home.sh     \
-         conf/hooks/10-shadow.sh   \
-         conf/hooks/98-nvidia.sh   \
-         conf/hooks/99-mellanox.sh \
+HOOKS := conf/hooks/10-aptfix.sh    \
+         conf/hooks/10-cgroups.sh   \
+         conf/hooks/10-devices.sh   \
+         conf/hooks/10-home.sh      \
+         conf/hooks/10-localtime.sh \
+         conf/hooks/10-shadow.sh    \
+         conf/hooks/98-nvidia.sh    \
+         conf/hooks/99-mellanox.sh  \
 
 CONFIG_EXTRA := conf/bash_completion
 

--- a/conf/hooks/10-localtime.sh
+++ b/conf/hooks/10-localtime.sh
@@ -1,0 +1,30 @@
+#! /usr/bin/env bash
+
+# Copyright (c) 2018-2023, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eu
+
+if [ ! -L /etc/localtime ] ; then
+    exit 0
+fi
+
+source "${ENROOT_LIBRARY_PATH}/common.sh"
+
+cp --no-dereference --preserve=links /etc/localtime "${ENROOT_ROOTFS}/etc/localtime"
+target="$(common::realpath /etc/localtime)"
+if [ ! -e "${ENROOT_ROOTFS}${target}" ] ; then
+    mkdir --parents "${ENROOT_ROOTFS}$(dirname "${target}")"
+    cp "${target}" "${ENROOT_ROOTFS}${target}"
+fi

--- a/conf/mounts/20-config.fstab
+++ b/conf/mounts/20-config.fstab
@@ -1,5 +1,4 @@
 /etc/hosts          /etc/hosts          none    x-create=file,bind,ro,nosuid,nodev,noexec,private                0   -1
 /etc/hostname       /etc/hostname       none    x-create=file,bind,ro,nosuid,nodev,noexec,private                0   -1
 /etc/resolv.conf    /etc/resolv.conf    none    x-create=file,bind,ro,nosuid,nodev,noexec,private                0   -1
-/etc/localtime      /etc/localtime      none    x-create=file,bind,ro,nosuid,nodev,noexec,private,nofail,silent  0   -1
 /etc/machine-id     /etc/machine-id     none    x-create=file,bind,ro,nosuid,nodev,noexec,private,nofail,silent  0   -1


### PR DESCRIPTION
With ubuntu 24.04, attempting to install the tzdata package inside an enroot container leads to the following error:
```
mv: cannot move '/etc/localtime.dpkg-new' to '/etc/localtime': Device or resource busy
```
The package's postinst script only skips setting the timezone if /etc/localtime already exists as a symlink. So, in order to set the timezone inside the container to match the host os, we must copy both the symlink and the symlink's target into the container rootfs.

See https://git.launchpad.net/~ubuntu-core-dev/ubuntu/+source/tzdata/tree/debian/tzdata.postinst?h=debian/2024a-1ubuntu1