### PR TITLE
[build] Fix arch detection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ DATADIR    = $(DESTDIR)$(datadir)/enroot
 
 VERSION       := 3.5.0
 PACKAGE       ?= enroot
-ARCH          ?= $(shell sh -c 'command -v dpkg-architecture >/dev/null && dpkg-architecture -q DEB_HOST_GNU_CPU || uname -m')
+ARCH          ?= $(shell uname -m)
 DEBUG         ?=
 CROSS_COMPILE ?=
 FORCE_GLIBC   ?=
@@ -97,6 +97,14 @@ ifdef CROSS_COMPILE
 CC       := $(CROSS_COMPILE)$(notdir $(CC))
 endif
 endif
+
+# Required for Debuild
+ifeq "$(ARCH:power%=p%)" "ppc64le"
+HOST_TYPE = $(shell $(CC) -dumpmachine)
+else
+HOST_TYPE = $(ARCH)-linux-gnu
+endif
+
 export CC ARCH CROSS_COMPILE
 
 # Compile the utilities statically against musl libc.
@@ -171,7 +179,7 @@ deb: export DEBEMAIL    := $(EMAIL)
 deb: clean
 	$(RM) -r debian
 	dh_make -y -d -s -c apache -t $(CURDIR)/pkg/deb -p $(PACKAGE)_$(VERSION) --createorig && cp -ar pkg/deb/source debian
-	debuild --preserve-env -us -uc -G -i -tc --host-type $(ARCH)-linux-gnu
+	debuild --preserve-env -us -uc -G -i -tc --host-type $(HOST_TYPE)
 	mkdir -p dist && find .. -maxdepth 1 -type f -name '$(PACKAGE)*' -exec mv {} dist \;
 	$(RM) -r debian
 

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ DATADIR    = $(DESTDIR)$(datadir)/enroot
 
 VERSION       := 3.5.0
 PACKAGE       ?= enroot
-ARCH          ?= $(shell uname -m)
+ARCH          ?= $(shell sh -c 'command -v dpkg-architecture >/dev/null && dpkg-architecture -q DEB_HOST_GNU_CPU || uname -m')
 DEBUG         ?=
 CROSS_COMPILE ?=
 FORCE_GLIBC   ?=


### PR DESCRIPTION
On ppc64le deb machines, when _not_ cross compiling, `uname -m` reports `ppc64le`, which is typically right. However, the "Debian machine triplet" that is necessary to build correctly uses `powerpc64le` for whatever reason. The cross compile path knows this and is explicit about that.

To alleviate that, use `dpkg-architecture` to discover the HOST _CPU_ type, which is what forms the machine triplet. The conditional check for `dpkg-architecture` should be safe and reports the right values for x86 and arm, too; falls back to `uname -m` anyways.