### PR TITLE
Use https instead of git for submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,7 +3,7 @@
 	url = https://github.com/megastep/makeself.git
 [submodule "deps/musl"]
 	path = deps/musl
-	url = git://git.musl-libc.org/musl
+	url = https://git.musl-libc.org/git/musl
 [submodule "deps/linux-headers"]
 	path = deps/linux-headers
 	url = https://github.com/sabotage-linux/kernel-headers.git


### PR DESCRIPTION
As the musl is now available through https protocol, use this to simplify granting access inside corporate environments.

Closes #119 