### PR TITLE
Add enroot export to usage doc example

### DIFF
--- a/doc/usage.md
+++ b/doc/usage.md
@@ -52,6 +52,9 @@ $ enroot start --rw cuda sh -c 'cd /usr/local/cuda/samples/Samples/0_Introductio
 # Run vectorAdd
 $ enroot start --rw cuda /usr/local/cuda/samples/Samples/0_Introduction/vectorAdd/vectorAdd
 
+# Export the modified container as a container image
+enroot export --output cuda-vecadd.sqsh cuda
+
 # Remove the container
 $ enroot remove cuda
 ```

--- a/doc/usage.md
+++ b/doc/usage.md
@@ -52,9 +52,6 @@ $ enroot start --rw cuda sh -c 'cd /usr/local/cuda/samples/Samples/0_Introductio
 # Run vectorAdd
 $ enroot start --rw cuda /usr/local/cuda/samples/Samples/0_Introduction/vectorAdd/vectorAdd
 
-# Export the modified container as a container image
-enroot export --output cuda-vecadd.sqsh cuda
-
 # Remove the container
 $ enroot remove cuda
 ```


### PR DESCRIPTION
This PR adds `enroot export ...` to the usage example. This shows users how to export the root filesystem image which will persist after `enroot remove ...`. Named container images may not persist on shared clusters, causing developers to lose their work (which has happened to me 😄 )