### PR TITLE
Apparmor profile must contain "profile enroot"

### DIFF
--- a/conf/apparmor.profile
+++ b/conf/apparmor.profile
@@ -1,7 +1,7 @@
 abi <abi/4.0>,
 include <tunables/global>
 
-/usr/bin/enroot-nsenter flags=(unconfined) {
+profile enroot /usr/bin/enroot-nsenter flags=(unconfined) {
     allow userns create,
     include if exists <local/enroot>
 }


### PR DESCRIPTION
AppArmor profiles are recommended to use the `profile` keyword when defining.

Ref: https://apparmor.net/reference/profiles-quick-reference/

The keyword "profile" is required when a separate name is present and is encouraged even when not required.

Vendors (without explicitly naming them) look for an AppArmor profile named `enroot` when init-ing.

This change would ensure this template is more use-able.

Thank you for your attention 🙇